### PR TITLE
adjust "files" key in pckg.json to incl index.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.22.2](https://github.com/microlinkhq/react-json-view/compare/v1.22.1...v1.22.2) (2022-06-21)
+- fix: update `package.json` to include `index.d.ts` to make the package TypeScript ready
 ### [1.22.1](https://github.com/microlinkhq/react-json-view/compare/v1.22.0...v1.22.1) (2022-05-11)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@microlink/react-json-view",
   "description": "Interactive react component for displaying javascript arrays and JSON objects.",
   "homepage": "https://github.com/microlinkhq/react-json-view",
-  "version": "1.22.2",
+  "version": "1.22.1",
   "main": "dist/main.js",
   "author": {
     "name": "Mac Gainor"

--- a/package.json
+++ b/package.json
@@ -223,9 +223,6 @@
     "webpack-cli": "~3.3.12",
     "webpack-dev-server": "~3.11.2"
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "NODE_ENV=production webpack --config webpack/webpack.config.js -p --display-error-details --progress --optimize-minimize",
     "build:demo": "NODE_ENV=production webpack --config webpack/webpack.config-demo.js -p --display-error-details --progress --optimize-minimize",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@microlink/react-json-view",
   "description": "Interactive react component for displaying javascript arrays and JSON objects.",
   "homepage": "https://github.com/microlinkhq/react-json-view",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "main": "dist/main.js",
   "author": {
     "name": "Mac Gainor"

--- a/package.json
+++ b/package.json
@@ -223,6 +223,10 @@
     "webpack-cli": "~3.3.12",
     "webpack-dev-server": "~3.11.2"
   },
+  "files": [
+    "dist",
+    "index.d.ts"
+  ],
   "scripts": {
     "build": "NODE_ENV=production webpack --config webpack/webpack.config.js -p --display-error-details --progress --optimize-minimize",
     "build:demo": "NODE_ENV=production webpack --config webpack/webpack.config-demo.js -p --display-error-details --progress --optimize-minimize",


### PR DESCRIPTION
Removing the `files` key in `package.json` results in the `index.d.ts` being included in the final package. This file is needed for the npm package being TypeScript ready.

This was fixed by Mac already a few years ago:
https://github.com/mac-s-g/react-json-view/issues/188#issuecomment-385587678