### PR TITLE
Add support for root name as jsx element

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or add to your package.json config file:
 Name|Type|Default|Description
 |:---|:---|:---|:---
 `src`|`JSON Object`|None|This property contains your input JSON
-`name`|`string` or `false`|"root"|Contains the name of your root node.  Use `null` or `false` for no name.
+`name`|`string`|`JSX.Element` or `false`|"root"|Contains the name of your root node.  Use `null` or `false` for no name.
 `theme`|`string`|"rjv-default"|RJV supports base-16 themes.  Check out the list of supported themes [in the demo](https://mac-s-g.github.io/react-json-view/demo/dist/). A custom "rjv-default" theme applies by default.
 `style`|`object`|`{}`|Style attributes for react-json-view container.  Explicit style attributes will override attributes provided by a theme.
 `iconStyle`|`string`|"circle"| Style of expand/collapse icons.  Accepted values are "circle", triangle" or "square".

--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -169,6 +169,13 @@ ReactDom.render(
             groupArraysAfterLength={50}
             src={getExampleJson4()}
         />
+
+        {/* Name as colored react component */}
+        <JsonViewer
+            collapsed
+            name={<span style={{color: "red", fontWeight: 800}}>React Element as name</span>}
+            src={getExampleJson2()}
+        />
     </div>,
     document.getElementById('app-container')
 );

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export interface ReactJsonViewProps {
    *
    * Default: "root"
    */
-  name?: string | null | false;
+  name?: React.JSX.Element | string | null | false;
   /**
    * RJV supports base-16 themes. Check out the list of supported themes in the demo.
    * A custom "rjv-default" theme applies by default.

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "@babel/plugin-syntax-class-properties": "~7.12.1",
     "@babel/plugin-syntax-jsx": "~7.12.1",
     "@babel/register": "7.12.10",
+    "@types/react": "^18.2.20",
     "babel-plugin-react-html-attrs": "~2.1.0",
     "chai": "~4.2.0",
     "css-loader": "~4.3.0",

--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -5,8 +5,11 @@ import ArrayGroup from './ArrayGroup';
 export default class extends React.PureComponent {
     render = () => {
         const { props } = this;
-        const namespace = [props.name];
+        let namespace = [props.name];
         let ObjectComponent = JsonObject;
+        if (typeof props.name === 'object' && !Array.isArray(props.name)) {
+            namespace = ['ReactElement'];
+        }
 
         if (
             Array.isArray(props.src) &&

--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -8,7 +8,9 @@ export default class extends React.PureComponent {
         let namespace = [props.name];
         let ObjectComponent = JsonObject;
         if (typeof props.name === 'object' && !Array.isArray(props.name)) {
-            namespace = [props.displayName || 'Anonymous'];
+            // Support Classes and Functional Components
+            const ComponentName = props.name?.displayName || props.name?.name || props.name?.type?.name;
+            namespace = [ComponentName || 'Anonymous'];
         }
 
         if (

--- a/src/js/components/JsonViewer.js
+++ b/src/js/components/JsonViewer.js
@@ -8,7 +8,7 @@ export default class extends React.PureComponent {
         let namespace = [props.name];
         let ObjectComponent = JsonObject;
         if (typeof props.name === 'object' && !Array.isArray(props.name)) {
-            namespace = ['ReactElement'];
+            namespace = [props.displayName || 'Anonymous'];
         }
 
         if (


### PR DESCRIPTION
As part of requirement of my current project we needed to use customary designs root name of each tree so easiest solution would be to pass React Element

![image](https://github.com/microlinkhq/react-json-view/assets/43639758/c65192ec-d8b0-4966-9088-6d07acc31207)

After trying some sketchy stuff I realized when I type cast `JSX.Element as string` nothing breaks within the library so started on checking out library code. 
After realization because of the support of `false` values in `ObjectAttributes` `object` type also works perfectly fine with exception that ObjectAttributes contains `[Object object]` as key

![image](https://github.com/microlinkhq/react-json-view/assets/43639758/2ada42df-4944-47da-a392-cd49d94ba816)

so it needed only adding handling to replace this `{} to string` to just be `"ReactElement" string` 

![image](https://github.com/microlinkhq/react-json-view/assets/43639758/7fcf2913-d350-4e87-878f-5719f60068b5)

Which I thought is the most appropriate name