### PR TITLE
:heavy_minus_sign: Removing "react-hot-loader" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,6 @@
     "react": "~16.14.0",
     "react-dom": "~16.14.0",
     "react-github-button": "~0.1.11",
-    "react-hot-loader": "~4.13.0",
     "react-scripts": "~5.0.1",
     "react-select": "~1.1.0",
     "react-test-renderer": "~16.14.0",


### PR DESCRIPTION
This package is deprecated and there's no plans to support it for React 18.
https://github.com/gaearon/react-hot-loader/issues/1808#issuecomment-1279728183

What do you think if we remove it?
The webpack `hot module replacement` works well even without "react-hot-loader".

The problem I'm trying to solve is this error:
<img width="1106" alt="Screenshot 2024-08-16 at 15 58 45" src="https://github.com/user-attachments/assets/55b09b46-e209-44db-9896-0e628b75a5bb">

Also I wanna update some dependencies to resolve all similar dependency errors.
