### PR TITLE
:green_heart: Fixing unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "treeview"
   ],
   "dependencies": {
+    "cheerio": "~1.0.0-rc.3",
     "flux": "~4.0.1",
     "react-base16-styling": "~0.6.0",
     "react-lifecycles-compat": "~3.0.4",
@@ -194,13 +195,13 @@
     "@types/react": "^18.2.20",
     "babel-plugin-react-html-attrs": "~2.1.0",
     "chai": "~4.2.0",
-    "github-generate-release": "latest",
     "css-loader": "~4.3.0",
-    "enzyme": "~3.2.0",
+    "enzyme": "~3.11.0",
     "enzyme-adapter-react-16": "~1.15.5",
     "eslint": "~7.16.0",
     "eslint-plugin-prettier": "~3.3.1",
     "eslint-plugin-react": "~7.21.5",
+    "github-generate-release": "latest",
     "html-webpack-plugin": "^4.5.2",
     "ignore-styles": "~5.0.1",
     "jsdom": "~16.4.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "treeview"
   ],
   "dependencies": {
-    "cheerio": "~1.0.0-rc.3",
+    "cheerio": "~1.0.0",
     "flux": "~4.0.1",
     "react-base16-styling": "~0.6.0",
     "react-lifecycles-compat": "~3.0.4",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "treeview"
   ],
   "dependencies": {
-    "cheerio": "~1.0.0",
     "flux": "~4.0.1",
     "react-base16-styling": "~0.6.0",
     "react-lifecycles-compat": "~3.0.4",
@@ -195,6 +194,7 @@
     "@types/react": "^18.2.20",
     "babel-plugin-react-html-attrs": "~2.1.0",
     "chai": "~4.2.0",
+    "cheerio": "1.0.0-rc.3",
     "css-loader": "~4.3.0",
     "enzyme": "~3.11.0",
     "enzyme-adapter-react-16": "~1.15.5",


### PR DESCRIPTION
Unit tests don't pass in the master branch.
They fail with the next error:
```
  2) <ArrayGroup />
       ArrayGroup renders at root:
     TypeError: Cannot read properties of undefined (reading 'load')
      at render (/home/runner/work/react-json-view/react-json-view/node_modules/enzyme/build/render.js:38:31)
      at Context.<anonymous> (/home/runner/work/react-json-view/react-json-view/test/tests/js/components/ArrayGroup-test.js:99:31)
      at processImmediate (node:internal/timers:483:21)
```

This error happens because of a broken pear dependancy of enzyme.
Enzyme imports "cheerio" package and uses a default export 👉 [here ](https://github.com/enzymejs/enzyme/blob/enzyme%403.2.0/packages/enzyme/src/render.js#L1)
But cheerio doesn't have any default export anymore 👉 [here](https://github.com/cheeriojs/cheerio/blob/main/src/index.ts)

The solution - update the enzyme version.

However, after the update we receive an another error. Enzyme imports some internal code from cheerio and it breaks the build.
The fix is to use a RC version of cheerio. Details - https://github.com/cheeriojs/cheerio/issues/2547