### PR TITLE
Use navigator.clipboard API

### DIFF
--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -46,11 +46,11 @@ export default class extends React.PureComponent {
         if (navigator.clipboard) {
             navigator.clipboard.writeText(textToCopy).catch(() => {
                 // Fallback for non-secure contexts (i.e. http)
-                copyToClipboardFallback(textToCopy);
+                this.copyToClipboardFallback(textToCopy);
             });
         } else {
             // Fallback for old browsers and test environments
-            copyToClipboardFallback(textToCopy);
+            this.copyToClipboardFallback(textToCopy);
         };
 
         this.copiedTimer = setTimeout(() => {

--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -35,7 +35,7 @@ export default class extends React.PureComponent {
         );
 
         if (navigator.clipboard) {
-            await navigator.clipboard.writeText(textToCopy);
+            navigator.clipboard.writeText(textToCopy);
         } else {
             console.error(
                 'react-json-view error:',

--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -25,6 +25,15 @@ export default class extends React.PureComponent {
         }
     }
 
+    copyToClipboardFallback = (textToCopy) => {
+        const textArea = document.createElement('textarea');
+        textArea.value = textToCopy;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+    }
+
     handleCopy = () => {
         const { clickCallback, src, namespace } = this.props;
 
@@ -35,21 +44,13 @@ export default class extends React.PureComponent {
         );
 
         if (navigator.clipboard) {
-            navigator.clipboard.writeText(textToCopy).catch(err => {
+            navigator.clipboard.writeText(textToCopy).catch(() => {
                 // Fallback for non-secure contexts (i.e. http)
-                const textArea = document.createElement('textarea');
-                textArea.value = textToCopy;
-                document.body.appendChild(textArea);
-                textArea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textArea);
+                copyToClipboardFallback(textToCopy);
             });
         } else {
-            console.error(
-                'react-json-view error:',
-                'navigator.clipboard not supported by this browser'
-            );
-            return;
+            // Fallback for old browsers and test environments
+            copyToClipboardFallback(textToCopy);
         };
 
         this.copiedTimer = setTimeout(() => {

--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { toType } from './../helpers/util';
 
-//clibboard icon
+//clipboard icon
 import { Clippy } from './icons';
 
 //theme
@@ -26,20 +26,23 @@ export default class extends React.PureComponent {
     }
 
     handleCopy = () => {
-        const container = document.createElement('textarea');
         const { clickCallback, src, namespace } = this.props;
 
-        container.innerHTML = JSON.stringify(
+        const textToCopy = JSON.stringify(
             this.clipboardValue(src),
             null,
             '  '
         );
 
-        document.body.appendChild(container);
-        container.select();
-        document.execCommand('copy');
-
-        document.body.removeChild(container);
+        if (navigator.clipboard) {
+            await navigator.clipboard.writeText(textToCopy);
+        } else {
+            console.error(
+                'react-json-view error:',
+                'navigator.clipboard not supported by this browser'
+            );
+            return;
+        };
 
         this.copiedTimer = setTimeout(() => {
             this.setState({

--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -35,7 +35,15 @@ export default class extends React.PureComponent {
         );
 
         if (navigator.clipboard) {
-            navigator.clipboard.writeText(textToCopy);
+            navigator.clipboard.writeText(textToCopy).catch(err => {
+                // Fallback for non-secure contexts (i.e. http)
+                const textArea = document.createElement('textarea');
+                textArea.value = textToCopy;
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textArea);
+            });
         } else {
             console.error(
                 'react-json-view error:',


### PR DESCRIPTION
Fixes issues with `document.execCommand('copy')` which is deprecated.

Uses `navigator.clipboard` instead which has [browser compatibility](https://caniuse.com/mdn-api_clipboard_writetext) of +93%.

Replaces #37