### PR TITLE
chore: update peer deps to support react v19;  fix nodejs to v18 to fix the tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 18
       - name: Install
         run: npm install --no-package-lock --force
       - name: Test

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
   "dependencies": {
     "react-base16-styling": "~0.9.0",
     "react-lifecycles-compat": "~3.0.4",
-    "react-textarea-autosize": "~8.3.2"
+    "react-textarea-autosize": "~8.5.7"
   },
   "devDependencies": {
     "@babel/core": "^7.13.0",
@@ -259,6 +259,9 @@
     "webpack-bundle-size-analyzer": "~3.1.0",
     "webpack-cli": "~5.1.4",
     "webpack-dev-server": "~5.0.4"
+  },
+  "engines": {
+    "node": "18"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Yarn reports that React 19 doesn't have a dependency resolution with the 8.3.2 version of react-textarea-autosize package.

Version 8.5.6 now lists React 19 as a peerDependency making this problem fixed.

Unfortunately, NodeJs LTS v22 support requires more work to fix the CI due to outdated tooling, so I suggest rolling it back to v18 to fix the CI and get the tests run as part of the build.