### PR TITLE
chore: bump react-textarea-autosize dep to allow react v19 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
   "dependencies": {
     "react-base16-styling": "~0.9.0",
     "react-lifecycles-compat": "~3.0.4",
-    "react-textarea-autosize": "~8.3.2"
+    "react-textarea-autosize": "~8.5.7"
   },
   "devDependencies": {
     "@babel/core": "^7.13.0",


### PR DESCRIPTION
Yarn reports that React 19 doesn't have a dependency resolution with the 8.3.2 version of react-textarea-autosize package.

Version 8.5.7 now lists React 19 as a peerDependency making this problem fixed.