### PR TITLE
fix: resolve test failures in Node 20+ and below Node 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
       - name: Install
         run: npm install --no-package-lock --force
       - name: Test

--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,4 @@ unsafe-perm=true
 loglevel=error
 shamefully-hoist=true
 resolution-mode=highest
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     "css-loader": "~4.3.0",
     "enzyme": "~3.11.0",
     "enzyme-adapter-react-16": "~1.15.5",
+    "finepack": "latest",
     "github-generate-release": "latest",
     "html-webpack-plugin": "^4.5.2",
     "ignore-styles": "~5.0.1",
@@ -259,6 +260,9 @@
     "webpack-bundle-size-analyzer": "~3.1.0",
     "webpack-cli": "~5.1.4",
     "webpack-dev-server": "~5.0.4"
+  },
+  "engines": {
+    "node": ">=17"
   },
   "files": [
     "dist",

--- a/test/testHelpers/requireSources.js
+++ b/test/testHelpers/requireSources.js
@@ -14,9 +14,12 @@ function setUpDomEnvironment () {
 
   global.window = window
   global.document = window.document
-  global.navigator = {
-    userAgent: 'node.js'
-  }
+  Object.defineProperty(global, 'navigator', {
+    value: {
+      userAgent: 'node.js'
+    },
+    writable: true
+  })
   copyProps(window, global)
 }
 


### PR DESCRIPTION
Node.js 22 enforces stricter protection on global object properties.

The original code attempted to modify the navigator property, which is read-only in newer versions.

Using Object.defineProperty correctly sets the property descriptor, making it writable.