### PR TITLE
refactor: better to check the constructor

### DIFF
--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -4,7 +4,7 @@ export function toType (obj, bigNumber) {
   /* Check if the object is an instance of the custom BigNumber class passed in as a prop
    * If it matches, return 'bigNumber' type so it can be displayed appropriately
    */
-  if (bigNumber && obj?.constructor?.name === bigNumber?.name) {
+  if (bigNumber && obj?.constructor === bigNumber) {
     return 'bigNumber'
   }
   let type = getType(obj)


### PR DESCRIPTION
It is safer to check the constructor instead of the name.