### PR TITLE
Fix CSP by removing globalThis polyfill

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -60,6 +60,9 @@ const config = {
         extractComments: false
       })
     ]
+  },
+  node: {
+    global: false // Prevents webpack from breaking CSP, see https://github.com/microlinkhq/react-json-view/issues/76
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/microlinkhq/react-json-view/issues/76

Tells webpack not to inject this polyfill, which looks like this (unminified):

```js
/******/ 	/* webpack/runtime/global */
/******/ 	(() => {
/******/ 		__webpack_require__.g = (function() {
/******/ 			if (typeof globalThis === 'object') return globalThis;
/******/ 			try {
/******/ 				return this || new Function('return this')();
/******/ 			} catch (e) {
/******/ 				if (typeof window === 'object') return window;
/******/ 			}
/******/ 		})();
/******/ 	})();
```

the `new Function('return this')` part is the bit that will break your CSP rules, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions

