### PR TITLE
fix: Fix toggleCollapsed handling sparse arrays

### DIFF
--- a/src/js/components/ArrayGroup.js
+++ b/src/js/components/ArrayGroup.js
@@ -20,9 +20,11 @@ export default class extends React.PureComponent {
   }
 
   toggleCollapsed = i => {
+    const { expanded } = this.state
     const newExpanded = []
-    for (const j in this.state.expanded) {
-      newExpanded.push(this.state.expanded[j])
+    const maxLength = Math.max(expanded.length || 0, i + 1)
+    for (let j = 0; j < maxLength; j++) {
+      newExpanded[j] = expanded[j] === true
     }
     newExpanded[i] = !newExpanded[i]
     this.setState({


### PR DESCRIPTION
Fixes #92

## Problem

The `toggleCollapsed` method in `ArrayGroup` component has a bug when handling sparse arrays. When `this.state.expanded` is a sparse array (e.g., only some indices are set to `true` while others are undefined), expanding and collapsing groups may trigger the wrong group to collapse or expand. This causes state inconsistencies where clicking on one group affects other groups unexpectedly.

## Root Cause

The original implementation used `for...in` loop which only iterates over defined indices in sparse arrays. This leads to:
- Missing indices in the new array
- Incorrect toggle behavior when switching undefined indices
- State inconsistencies

## Solution

- Replace `for...in` with a standard `for` loop to ensure all required indices are processed
- Calculate the maximum length needed (current array length or target index + 1)
- Explicitly initialize undefined indices to `false` to avoid sparse array issues
- Use strict equality check (`=== true`) for clarity

## Changes

- Modified `toggleCollapsed` method to properly handle sparse arrays
- Ensures all indices are correctly initialized and toggled
