### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,12 +287,12 @@
     "react-textarea-autosize": "~8.5.9"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.0",
-    "@babel/eslint-parser": "~7.29.7",
+    "@babel/core": "^8.0.0",
+    "@babel/eslint-parser": "~8.0.0",
     "@babel/plugin-proposal-private-property-in-object": "~7.21.11",
-    "@babel/plugin-syntax-class-properties": "~7.12.1",
-    "@babel/plugin-syntax-jsx": "~7.29.7",
-    "@babel/register": "7.29.7",
+    "@babel/plugin-syntax-class-properties": "~7.12.13",
+    "@babel/plugin-syntax-jsx": "~8.0.0",
+    "@babel/register": "8.0.0",
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
     "babel-loader": "10.1.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Major-version Babel upgrades can break webpack builds, ESLint parsing, or Mocha test transpilation until CI passes; published library code is unaffected.
> 
> **Overview**
> Bumps the **Babel 7 → 8** dev toolchain in `package.json`: `@babel/core`, `@babel/eslint-parser`, `@babel/plugin-syntax-jsx`, and `@babel/register` move to 8.x, with a minor pin bump on `@babel/plugin-syntax-class-properties`. **Runtime `dependencies` are unchanged**; this only affects build, lint, and test (`@babel/register` in the mocha scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9eb81a94d13b595943e847ff26506af30e2867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->