### PR TITLE
fix: copy string values without JSON quotes

### DIFF
--- a/src/js/components/CopyToClipboard.js
+++ b/src/js/components/CopyToClipboard.js
@@ -37,7 +37,7 @@ export default class extends React.PureComponent {
   handleCopy = () => {
     const { clickCallback, src, namespace } = this.props
 
-    const textToCopy = JSON.stringify(this.clipboardValue(src), null, '  ')
+    const textToCopy = this.clipboardText(src)
 
     if (navigator.clipboard) {
       navigator.clipboard.writeText(textToCopy).catch(() => {
@@ -92,6 +92,16 @@ export default class extends React.PureComponent {
       default:
         return value
     }
+  }
+
+  clipboardText = value => {
+    const clipboardValue = this.clipboardValue(value)
+
+    if (typeof clipboardValue === 'string') {
+      return clipboardValue
+    }
+
+    return JSON.stringify(clipboardValue, null, '  ')
   }
 
   render () {

--- a/test/tests/js/components/CopyToClipboard-test.js
+++ b/test/tests/js/components/CopyToClipboard-test.js
@@ -4,6 +4,36 @@ import { expect } from 'chai'
 
 import CopyToClipboard from './../../../../src/js/components/CopyToClipboard'
 
+function copyToClipboard (src) {
+  const copied = []
+  const { clipboard } = global.navigator
+
+  global.navigator.clipboard = {
+    writeText: textToCopy => {
+      copied.push(textToCopy)
+      return Promise.resolve()
+    }
+  }
+
+  const wrapper = shallow(
+    <CopyToClipboard
+      src={src}
+      namespace={['root']}
+      theme='rjv-default'
+      hidden={false}
+    />
+  )
+
+  try {
+    wrapper.find('.copy-to-clipboard-container').childAt(0).simulate('click')
+  } finally {
+    wrapper.unmount()
+    global.navigator.clipboard = clipboard
+  }
+
+  return copied
+}
+
 describe('<CopyToClipboard />', function () {
   it('CopyToClipboard clipboard should exist', function () {
     const wrapper = shallow(
@@ -28,5 +58,42 @@ describe('<CopyToClipboard />', function () {
     )
     // not sure how to test css attribute
     expect(wrapper.find('.copy-to-clipboard-container')).to.have.length(1)
+  })
+
+  it('CopyToClipboard copies a string without quotes', function () {
+    expect(copyToClipboard('a string')).to.deep.equal(['a string'])
+  })
+
+  it('CopyToClipboard copies an object as JSON', function () {
+    expect(copyToClipboard({ test: true })).to.deep.equal([
+      JSON.stringify({ test: true }, null, '  ')
+    ])
+  })
+
+  it('CopyToClipboard copies an array as JSON', function () {
+    expect(copyToClipboard(['a string', 1])).to.deep.equal([
+      JSON.stringify(['a string', 1], null, '  ')
+    ])
+  })
+
+  it('CopyToClipboard copies a number as JSON', function () {
+    expect(copyToClipboard(1)).to.deep.equal(['1'])
+  })
+
+  it('CopyToClipboard copies a boolean as JSON', function () {
+    expect(copyToClipboard(true)).to.deep.equal(['true'])
+  })
+
+  it('CopyToClipboard copies null as JSON', function () {
+    expect(copyToClipboard(null)).to.deep.equal(['null'])
+  })
+
+  it('CopyToClipboard copies a function as source text', function () {
+    const noop = function () {}
+    expect(copyToClipboard(noop)).to.deep.equal([noop.toString()])
+  })
+
+  it('CopyToClipboard copies a regexp as source text', function () {
+    expect(copyToClipboard(/pattern/g)).to.deep.equal(['/pattern/g'])
   })
 })


### PR DESCRIPTION
## The problem

Clicking the clipboard icon on a string value copies `"my value"` — quotes included — because `handleCopy` runs every node through `JSON.stringify`:

```js
const textToCopy = JSON.stringify(this.clipboardValue(src), null, '  ')
```

For object and array nodes that is exactly right, and numbers and booleans are unaffected (`5`, `true`), but a leaf string's JSON form *is* a quoted string literal, so the quotes end up on the clipboard and have to be removed by hand after pasting.

Originally reported in mac-s-g/react-json-view#217 and mac-s-g/react-json-view#167.

The workaround people are pointed to is to re-copy the value from the `enableClipboard` callback. That is no longer reliable: the callback runs *after* `handleCopy` has already written, and in browsers that permit a single clipboard write per user gesture the second write is rejected with `NotAllowedError`, leaving the quoted value on the clipboard.

## The change

`clipboardText` copies a value that is already text verbatim, and keeps `JSON.stringify` for everything else:

| node | before | after |
| --- | --- | --- |
| string | `"my value"` | `my value` |
| function / regexp | JSON-escaped one-liner | source text (they are already passed through `toString()` by `clipboardValue`) |
| object, array, number, boolean, null | unchanged | unchanged |

Tests covering each case are added to `test/tests/js/components/CopyToClipboard-test.js`; the suite passes (200 tests), and the two new string/function cases fail against `master` without the source change.

Happy to rework this if you would rather have it behind a prop, or expose the text through a return value from the `enableClipboard` callback instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copying text now preserves string values exactly.
  * Non-string values are consistently formatted for clipboard use, including objects, arrays, numbers, booleans, null values, functions, and regular expressions.

* **Tests**
  * Added coverage for copying and formatting multiple value types.
  * Added clipboard interaction tests to verify the text written during copy actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->