### PR TITLE
fix(types): add missing showComma prop to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,6 +165,12 @@ export interface ReactJsonViewProps {
    * Default: true
    */
   escapeStrings?: boolean
+  /**
+   * Whether to show commas between object properties
+   *
+   * Default: true
+   */
+  showComma?: boolean
 }
 
 export interface OnCopyProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ export interface ReactJsonViewProps {
    */
   escapeStrings?: boolean
   /**
-   * Whether to show commas between object properties
+   * Whether to show commas between object properties and array elements
    *
    * Default: true
    */


### PR DESCRIPTION
https://github.com/microlinkhq/react-json-view/issues/100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to control whether commas appear between object properties and array elements.
  - Commas are shown by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->